### PR TITLE
Renames isAlive to is_alive to ensure Python 3.9 compatibility

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -112,7 +112,7 @@ def start_thread(func):
 
 def wait(thread):
     i = 1
-    while thread.isAlive():
+    while thread.is_alive():
         print('Waiting %s%s' % ('.' * i, ' ' * (3 - i)), end='\r')
         i = i + 1 if i < 3 else 1
         time.sleep(0.4)

--- a/downloader.py
+++ b/downloader.py
@@ -112,7 +112,12 @@ def start_thread(func):
 
 def wait(thread):
     i = 1
-    while thread.is_alive():
+    if sys.version_info.major == 3 and sys.version_info.minor >= 9:
+        living_thread = thread.is_alive
+    else:
+        living_thread = thread.isAlive
+
+    while living_thread():
         print('Waiting %s%s' % ('.' * i, ' ' * (3 - i)), end='\r')
         i = i + 1 if i < 3 else 1
         time.sleep(0.4)


### PR DESCRIPTION
Simple change - method name changed on Python 3.9.