### PR TITLE
Make the tool compatible with older versions of Python

### DIFF
--- a/src/datacamp_downloader/session.py
+++ b/src/datacamp_downloader/session.py
@@ -4,6 +4,7 @@ import pickle
 from pathlib import Path
 from .datacamp_utils import Datacamp
 from .constants import SESSION_FILE
+import os
 
 
 class Session:
@@ -45,7 +46,10 @@ class Session:
         s.headers = headers
         self.session = cloudscraper.create_scraper(s)
         # remove old session
-        self.savefile.unlink(missing_ok=True)
+        try:
+            os.remove(self.savefile)
+        except:
+            pass
         return self
 
     def get(self, *args, **kwargs):

--- a/src/datacamp_downloader/templates/track.py
+++ b/src/datacamp_downloader/templates/track.py
@@ -1,11 +1,15 @@
-from dataclasses import dataclass, field
 from typing import List
 from .course import Course
 
 
-@dataclass
 class Track:
     id: int
     title: str
     link: str
-    courses: List[Course] = field(default_factory=list)
+    courses: List[Course]
+
+    def __init__(self, id: int, title: str, link: str) -> None:
+        self.id = id
+        self.title = title
+        self.link = link
+        self.courses = []


### PR DESCRIPTION
The following changes were made:
- Removed imports from `dataclasses` since they got introduced in python 3.7.
- Changed `~.unlink` to `os.remove` because `missing_ok` parameter was added in python 3.8.